### PR TITLE
Add support for drag'n'drop onto the application in file explorer.

### DIFF
--- a/Slideshow/App.xaml
+++ b/Slideshow/App.xaml
@@ -1,6 +1,7 @@
 ﻿<Application x:Class="Slideshow.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             Startup="App_Startup"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
          

--- a/Slideshow/App.xaml.cs
+++ b/Slideshow/App.xaml.cs
@@ -23,5 +23,18 @@ namespace Slideshow
     /// </summary>
     public partial class App : Application
     {
+        void App_Startup(object sender, StartupEventArgs e)
+        {
+            if (e.Args.Length > 0)
+            {
+                dragNdropArg = e.Args[0];
+            }
+            else
+            {
+                dragNdropArg = "";
+            }
+        }
+
+        public static string dragNdropArg;
     }
 }

--- a/Slideshow/MainWindow.xaml.cs
+++ b/Slideshow/MainWindow.xaml.cs
@@ -123,12 +123,18 @@ namespace Slideshow
                 case Key.Subtract:
                 // Break intentionally omitted.
                 case Key.OemMinus:
-                    if (imageDurationSeconds - imageDurationOffset < 1)
+                    if (imageDurationSeconds <= 1)
                     {
                         break;
                     }
-
-                    imageDurationSeconds -= imageDurationOffset;
+                    if (imageDurationSeconds >= (imageDurationOffset * 2))
+                    {
+                        imageDurationSeconds -= imageDurationOffset;
+                    }
+                    else
+                    {
+                        imageDurationSeconds /= 2;
+                    }
                     imageTimer.Interval = new TimeSpan(0, 0, imageDurationSeconds);
                     Toast(String.Format("Decreased duration to {0} seconds", imageDurationSeconds));
                     break;
@@ -233,7 +239,15 @@ namespace Slideshow
         private void LoadImages()
         {
             string[] validExtensions = new string[] { ".jpg", ".jpeg" };
-            DirectoryInfo directory = new DirectoryInfo(GetAssemblyDirectory());
+            DirectoryInfo directory;
+            if (Slideshow.App.dragNdropArg.Length > 0)
+            {
+                directory = new DirectoryInfo(GetSelectedDirectory(Slideshow.App.dragNdropArg));
+            }
+            else
+            {
+                directory = new DirectoryInfo(GetAssemblyDirectory());
+            }
             IEnumerable<FileInfo> files = from f in directory.EnumerateFiles()
                                           where validExtensions.Any(f.Extension.ToLower().Contains)
                                           select f;
@@ -252,6 +266,17 @@ namespace Slideshow
             UriBuilder uri = new UriBuilder(codeBase);
             string assemblyPath = Uri.UnescapeDataString(uri.Path);
             return Path.GetDirectoryName(assemblyPath);
+        }
+
+        private string GetSelectedDirectory(string arg)
+        {
+            UriBuilder uri = new UriBuilder(arg);
+            string argPath = Uri.UnescapeDataString(uri.Path);
+            if (Directory.Exists(argPath))
+            {
+                return argPath;
+            }
+            return Path.GetDirectoryName(argPath);
         }
     }
 }


### PR DESCRIPTION
My guess is that this project is not being actively maintained, but the Slideshow application was almost exactly what I wanted for my parents - the simpler the better, but with some ability to control the duration. The only additional feature that I wanted was to be able to drag'n'drop a folder of pictures onto the application rather than need to have the application in the folder with the pictures.

I've added the code to do that. I'm not a regular C#/.NET developer, so there might be better ways to do this?

I also made a small tweak to the duration decrement code so that it reduces by 50% once it gets down to less than 8 seconds.
